### PR TITLE
Add style for h5

### DIFF
--- a/assets/css/customstyles.css
+++ b/assets/css/customstyles.css
@@ -649,6 +649,7 @@ a.fa.fa-envelope-o.mailto {
 
 h3 {color: #ED1951; font-weight:normal; font-size:130%;}
 h4 {color: #000000; font-weight:normal; font-size:120%; font-weight:bold;}
+h5 {color: #000000; font-weight:normal; font-size:110%; font-weight:bold;}
 
 .alert, .callout {
     overflow: hidden;


### PR DESCRIPTION
Add a style for h5 elements to allow them to be slightly bigger than text. This will allow us to add sections in the function documentation for instance when adapting from a numpy docstyle where function docs strings have sections for parameters, exceptions, and returns.